### PR TITLE
Enable github actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,10 @@
-# DISABLED: This workflow is disabled due to repository ownership restrictions
-# To re-enable, transfer repository ownership to "hersouls" organization
-# or use the alternative deployment methods in DEPLOYMENT.md
+name: CI/CD Pipeline
 
-name: CI/CD Pipeline (DISABLED)
-
-# on:
-#   push:
-#     branches: [ main, develop ]
-#   pull_request:
-#     branches: [ main, develop ]
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
 
 jobs:
   # 코드 품질 검사

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,8 +1,4 @@
-# DISABLED: This workflow is disabled due to repository ownership restrictions
-# To re-enable, transfer repository ownership to "hersouls" organization
-# or use the alternative deployment methods in DEPLOYMENT.md
-
-name: Deploy to GitHub Pages (DISABLED)
+name: Deploy to GitHub Pages
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,9 @@
-# DISABLED: This workflow is disabled due to repository ownership restrictions
-# To re-enable, transfer repository ownership to "hersouls" organization
+name: Release
 
-name: Release (DISABLED)
-
-# on:
-#   push:
-#     tags:
-#       - 'v*' # v1.0.0, v1.1.0 등
+on:
+  push:
+    tags:
+      - 'v*' # v1.0.0, v1.1.0 등
 
 jobs:
   release:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,13 +1,10 @@
-# DISABLED: This workflow is disabled due to repository ownership restrictions
-# To re-enable, transfer repository ownership to "hersouls" organization
+name: Security & Dependencies
 
-name: Security & Dependencies (DISABLED)
-
-# on:
-#   schedule:
-#     # 매주 월요일 오전 9시에 실행
-#     - cron: '0 9 * * 1'
-#   workflow_dispatch: # 수동 실행 가능
+on:
+  schedule:
+    # 매주 월요일 오전 9시에 실행
+    - cron: '0 9 * * 1'
+  workflow_dispatch: # 수동 실행 가능
 
 jobs:
   # 보안 취약점 검사


### PR DESCRIPTION
Re-enable GitHub Actions workflows by uncommenting `on:` sections, renaming `pages.yml.disabled`, and removing ownership restriction comments.

---

[Open in Web](https://cursor.com/agents?id=bc-28b42bda-a1ff-435b-b9b2-3a2cf4ff5071) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-28b42bda-a1ff-435b-b9b2-3a2cf4ff5071) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)