### PR TITLE
Fix typescript errors in react components

### DIFF
--- a/SMS_V.2.0/src/components/features/monitoring/ErrorBoundary.tsx
+++ b/SMS_V.2.0/src/components/features/monitoring/ErrorBoundary.tsx
@@ -1,3 +1,5 @@
+import { Component } from 'react';
+import type { ReactNode } from 'react';
 
 
 interface ErrorInfo {

--- a/SMS_V.2.0/src/contexts/ExchangeRateContext.tsx
+++ b/SMS_V.2.0/src/contexts/ExchangeRateContext.tsx
@@ -1,4 +1,6 @@
 
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import type { ReactNode } from 'react';
 import { supabase } from '../lib/supabase';
 import { useAuth } from './AuthContext';
 


### PR DESCRIPTION
Add missing React imports and use type-only imports for types to resolve TypeScript compilation errors.

---

[Open in Web](https://cursor.com/agents?id=bc-227b7deb-f5ac-47ea-943a-b40a42af3ca1) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-227b7deb-f5ac-47ea-943a-b40a42af3ca1) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)