### PR TITLE
Install husky for project preparation

### DIFF
--- a/SMS_V.2.0/package.json
+++ b/SMS_V.2.0/package.json
@@ -20,7 +20,7 @@
     "type-check": "tsc --noEmit",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json,css,md}\"",
-    "prepare": "husky install",
+    "prepare": "if command -v husky >/dev/null 2>&1; then husky install; else echo 'Husky not available, skipping install'; fi",
     "deploy": "npm run build && gh pages deploy dist/ --branch gh-pages --clean",
     "deploy:manual": "npm run build",
     "install-deps": "npm ci --legacy-peer-deps",


### PR DESCRIPTION
Modify `prepare` script to allow `npm ci --dry-run` to succeed.

The `prepare` script previously failed `npm ci --dry-run` because `husky` was not available. The updated script checks for `husky`'s presence before attempting to install it, preventing errors during dry runs while maintaining functionality for full installations.

---

[Open in Web](https://cursor.com/agents?id=bc-abab45c5-4c89-4e00-9fc4-7e7f2feb046c) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-abab45c5-4c89-4e00-9fc4-7e7f2feb046c) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)