### PR TITLE
Lint unused user variable in signup page

### DIFF
--- a/SMS_V.2.0/src/pages/auth/Signup.tsx
+++ b/SMS_V.2.0/src/pages/auth/Signup.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { Mail, Lock, Eye, EyeOff, XCircle, User } from 'lucide-react';
+import { Mail, Lock, Eye, EyeOff, XCircle } from 'lucide-react';
 import { useAuth } from '../../hooks/useAuth';
 import { cn } from '../../lib/utils';
 import AuthLayout from '../../components/layout/AuthLayout';


### PR DESCRIPTION
Remove unused `User` import to resolve a linting error.

---

[Open in Web](https://cursor.com/agents?id=bc-14df518a-3218-46e8-af9f-5964c988a412) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-14df518a-3218-46e8-af9f-5964c988a412) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)