### PR TITLE
Fix typescript build error

### DIFF
--- a/SMS_V.2.0/package.json
+++ b/SMS_V.2.0/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "npx tsc -b && vite build",
     "preview": "vite preview",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/SMS_V.2.0/src/pages/auth/Signup.tsx
+++ b/SMS_V.2.0/src/pages/auth/Signup.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { Mail, Lock, Eye, EyeOff, XCircle } from 'lucide-react';
+import { Mail, Lock, Eye, EyeOff, XCircle, CheckCircle } from 'lucide-react';
 import { useAuth } from '../../hooks/useAuth';
 import { cn } from '../../lib/utils';
 import AuthLayout from '../../components/layout/AuthLayout';


### PR DESCRIPTION
Import `CheckCircle` and update the build script to fix a TypeScript error and enable successful project build.

The build was failing due to `CheckCircle` being used without import and the `tsc` command not correctly resolving the local TypeScript installation.

---

[Open in Web](https://cursor.com/agents?id=bc-2c5ff1f6-972c-4455-88c2-0efc3706008b) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-2c5ff1f6-972c-4455-88c2-0efc3706008b) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)