### PR TITLE
Lint and type check for unused variables

### DIFF
--- a/SMS_V.2.0/src/components/features/SubscriptionsPage.tsx
+++ b/SMS_V.2.0/src/components/features/SubscriptionsPage.tsx
@@ -9,9 +9,6 @@ import {
   PauseIcon,
   XMarkIcon,
   ExternalLinkIcon,
-  HomeIcon,
-  BellIcon,
-  UserIcon,
   Bars3Icon,
   ArrowLeftIcon
 } from '@heroicons/react/24/outline';
@@ -212,7 +209,6 @@ interface SubscriptionCardProps {
 }
 
 const SubscriptionCard: React.FC<SubscriptionCardProps> = ({ subscription, viewMode }) => {
-  const isActive = subscription.status === 'active';
   const statusColors = {
     active: 'text-green-600',
     paused: 'text-yellow-600',


### PR DESCRIPTION
Remove unused imports and the `isActive` variable to resolve linting errors.

---

[Open in Web](https://cursor.com/agents?id=bc-760698b2-74f8-4cb1-b2cb-0acca93f3be9) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-760698b2-74f8-4cb1-b2cb-0acca93f3be9) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)