### PR TITLE
Implement layout system and fix alignment

### DIFF
--- a/SMS_V.2.0/src/components/layout/MainLayout.tsx
+++ b/SMS_V.2.0/src/components/layout/MainLayout.tsx
@@ -42,9 +42,7 @@ const MainLayout: React.FC<MainLayoutProps> = ({
           <div className="frame-content">
             {/* Content Frame with improved centering */}
             <div className="frame-content-inner flex flex-col items-center justify-center min-h-full">
-              <div className="w-full max-w-4xl mx-auto px-4 @sm:px-6 @lg:px-8">
-                {children}
-              </div>
+              {children}
             </div>
           </div>
         </main>

--- a/SMS_V.2.0/src/index.css
+++ b/SMS_V.2.0/src/index.css
@@ -238,11 +238,11 @@
   }
 
   .frame-content {
-    @apply flex-1 container mx-auto px-4 @sm:px-6 @lg:px-8 py-4 @sm:py-6 @lg:py-8;
+    @apply flex-1 w-full max-w-7xl mx-auto px-6 py-4 @sm:py-6 @lg:py-8;
   }
 
   .frame-content-inner {
-    @apply max-w-7xl mx-auto flex flex-col items-center justify-center min-h-full;
+    @apply w-full flex flex-col items-center justify-center min-h-full;
   }
 
   .frame-footer {
@@ -297,6 +297,44 @@
 
   .button-group-centered {
     @apply flex items-center justify-center gap-2 @sm:gap-3 @lg:gap-4;
+  }
+
+  /* Grid System - Design Guide 표준 */
+  .grid-system {
+    @apply grid gap-6;
+  }
+
+  .grid-system-1 {
+    @apply grid-cols-1;
+  }
+
+  .grid-system-2 {
+    @apply grid-cols-1 md:grid-cols-2;
+  }
+
+  .grid-system-3 {
+    @apply grid-cols-1 md:grid-cols-2 lg:grid-cols-3;
+  }
+
+  .grid-system-4 {
+    @apply grid-cols-1 md:grid-cols-2 lg:grid-cols-4;
+  }
+
+  /* Layout System - Design Guide 표준 */
+  .layout-container {
+    @apply w-full max-w-7xl mx-auto px-6;
+  }
+
+  .layout-container-sm {
+    @apply w-full max-w-4xl mx-auto px-6;
+  }
+
+  .layout-container-lg {
+    @apply w-full max-w-6xl mx-auto px-6;
+  }
+
+  .layout-container-xl {
+    @apply w-full max-w-7xl mx-auto px-6;
   }
 }
 

--- a/SMS_V.2.0/src/pages/Calendar.tsx
+++ b/SMS_V.2.0/src/pages/Calendar.tsx
@@ -89,7 +89,7 @@ const Calendar: React.FC = () => {
   if (isLoading) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100">
-        <div className="container mx-auto px-4 py-8">
+        <div className="w-full max-w-7xl mx-auto px-6 py-8">
           <div className="animate-pulse">
             <div className="h-8 bg-gray-200 rounded w-1/4 mb-8"></div>
             <div className="bg-white rounded-xl shadow-sm p-6">
@@ -103,7 +103,7 @@ const Calendar: React.FC = () => {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100">
-      <div className="container mx-auto px-4 py-8">
+      <div className="w-full max-w-7xl mx-auto px-6 py-8">
         {/* Header */}
         <div className="mb-8">
           <h1 className="text-3xl font-bold font-pretendard text-gray-900 tracking-ko-tight break-keep-ko mb-2">

--- a/SMS_V.2.0/src/pages/Dashboard.tsx
+++ b/SMS_V.2.0/src/pages/Dashboard.tsx
@@ -161,7 +161,7 @@ const Dashboard: React.FC = () => {
 
   if (loading) {
     return (
-      <div className="container mx-auto px-4 py-8">
+      <div className="w-full max-w-7xl mx-auto px-6 py-8">
         {/* Header Skeleton */}
         <div className="mb-8 animate-pulse">
           <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-48 mb-2"></div>
@@ -235,7 +235,7 @@ const Dashboard: React.FC = () => {
   // Error state
   if (error) {
     return (
-      <div className="container mx-auto px-4 py-8">
+      <div className="w-full max-w-7xl mx-auto px-6 py-8">
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2 break-keep-ko">
             Dashboard
@@ -275,7 +275,7 @@ const Dashboard: React.FC = () => {
   }
 
   return (
-    <div className="container mx-auto px-4 py-8">
+    <div className="w-full max-w-7xl mx-auto px-6 py-8">
       {/* Header */}
       <div className="mb-8">
         <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2 break-keep-ko">

--- a/SMS_V.2.0/src/pages/Settings.tsx
+++ b/SMS_V.2.0/src/pages/Settings.tsx
@@ -45,7 +45,7 @@ const Settings: React.FC = () => {
   };
 
   return (
-    <div className="container mx-auto px-4 py-8 max-w-4xl">
+    <div className="w-full max-w-7xl mx-auto px-6 py-8">
       {/* Header */}
       <div className="mb-8">
         <h1 className="text-3xl font-bold text-gray-900 mb-2 break-keep-ko">

--- a/SMS_V.2.0/src/pages/Subscriptions.tsx
+++ b/SMS_V.2.0/src/pages/Subscriptions.tsx
@@ -137,7 +137,7 @@ const Subscriptions: React.FC = () => {
 
   if (loading) {
     return (
-      <div className="container mx-auto px-4 py-8">
+      <div className="w-full max-w-7xl mx-auto px-6 py-8">
         <div className="animate-pulse space-y-6">
           <div className="h-8 bg-gray-200 rounded w-1/4"></div>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -151,7 +151,7 @@ const Subscriptions: React.FC = () => {
   }
 
   return (
-    <div className="container mx-auto px-4 py-8">
+    <div className="w-full max-w-7xl mx-auto px-6 py-8">
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-8">
         <div>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Implement Moonwave layout system for central alignment and max-width, fixing left-aligned elements and standardizing page containers.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR addresses the "absence of layout system" bug by applying `max-w-7xl`, `mx-auto`, and `px-6` classes as specified in the Moonwave Design Guide (6, 11.5) to `Dashboard`, `Subscriptions`, `Calendar`, and `Settings` pages. It also removes a redundant container in `MainLayout.tsx` and introduces new utility classes for a consistent grid and layout system in `index.css`.

---

[Open in Web](https://cursor.com/agents?id=bc-cf2324eb-08c6-4789-8fbd-e9fc9c8af540) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-cf2324eb-08c6-4789-8fbd-e9fc9c8af540) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)