### PR TITLE
Apply design tokens for consistent spacing and typography

### DIFF
--- a/SMS_V.2.0/src/components/layout/MainLayout.tsx
+++ b/SMS_V.2.0/src/components/layout/MainLayout.tsx
@@ -42,9 +42,9 @@ const MainLayout: React.FC<MainLayoutProps> = ({
           <div className="frame-content">
             {/* Content Frame with improved centering */}
             <div className="frame-content-inner flex flex-col items-center justify-center min-h-full">
-              <div className="w-full max-w-4xl mx-auto px-4 @sm:px-6 @lg:px-8">
-                {children}
-              </div>
+                          <div className="w-full max-w-4xl mx-auto px-4 @sm:px-6 @lg:px-8 py-4 @sm:py-6 @lg:py-8">
+              {children}
+            </div>
             </div>
           </div>
         </main>

--- a/SMS_V.2.0/src/pages/Dashboard.tsx
+++ b/SMS_V.2.0/src/pages/Dashboard.tsx
@@ -237,10 +237,10 @@ const Dashboard: React.FC = () => {
     return (
       <div className="container mx-auto px-4 py-8">
         <div className="mb-8">
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2 break-keep-ko">
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2 break-keep-ko font-pretendard tracking-ko-tight">
             Dashboard
           </h1>
-          <p className="text-gray-600 dark:text-gray-400 break-keep-ko">
+          <p className="text-base text-gray-600 dark:text-gray-400 break-keep-ko font-pretendard tracking-ko-normal">
             Welcome back! Here's an overview of your subscriptions.
           </p>
         </div>
@@ -253,10 +253,10 @@ const Dashboard: React.FC = () => {
               </svg>
             </div>
             <div>
-              <h3 className="text-lg font-semibold text-red-800 dark:text-red-200">
+              <h3 className="text-lg font-semibold text-red-800 dark:text-red-200 font-pretendard tracking-ko-tight">
                 오류가 발생했습니다
               </h3>
-              <p className="text-red-700 dark:text-red-300 mt-1">
+              <p className="text-base text-red-700 dark:text-red-300 mt-1 font-pretendard tracking-ko-normal">
                 {error}
               </p>
             </div>
@@ -278,10 +278,10 @@ const Dashboard: React.FC = () => {
     <div className="container mx-auto px-4 py-8">
       {/* Header */}
       <div className="mb-8">
-        <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2 break-keep-ko">
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2 break-keep-ko font-pretendard tracking-ko-tight">
           Dashboard
         </h1>
-        <p className="text-gray-600 dark:text-gray-400 break-keep-ko">
+        <p className="text-base text-gray-600 dark:text-gray-400 break-keep-ko font-pretendard tracking-ko-normal">
           Welcome back! Here's an overview of your subscriptions.
         </p>
       </div>
@@ -295,10 +295,10 @@ const Dashboard: React.FC = () => {
               <CardContent className="p-6">
                 <div className="flex items-center justify-between">
                   <div>
-                    <p className="text-sm font-medium text-gray-600 dark:text-gray-400 break-keep-ko">
+                    <p className="text-sm font-medium text-gray-600 dark:text-gray-400 break-keep-ko font-pretendard tracking-ko-normal">
                       {card.title}
                     </p>
-                    <p className="text-2xl font-bold text-gray-900 dark:text-white mt-1">
+                    <p className="text-2xl font-bold text-gray-900 dark:text-white mt-1 font-pretendard tracking-ko-tight text-numeric">
                       {card.value}
                     </p>
                   </div>
@@ -326,7 +326,7 @@ const Dashboard: React.FC = () => {
         {/* Active Subscriptions */}
         <Card className="lg:col-span-2">
           <CardHeader>
-            <CardTitle className="flex items-center gap-2">
+            <CardTitle className="flex items-center gap-2 font-pretendard tracking-ko-tight">
               <Users className="w-5 h-5 text-blue-600" />
               Active Subscriptions
             </CardTitle>
@@ -337,10 +337,10 @@ const Dashboard: React.FC = () => {
                 <div className="w-20 h-20 bg-gray-100 dark:bg-gray-700 rounded-full flex items-center justify-center mx-auto mb-6">
                   <CreditCard className="w-10 h-10 text-gray-400" />
                 </div>
-                <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2 break-keep-ko">
+                <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2 break-keep-ko font-pretendard tracking-ko-tight">
                   No active subscriptions found
                 </h3>
-                <p className="text-gray-500 dark:text-gray-400 mb-6 break-keep-ko">
+                <p className="text-base text-gray-500 dark:text-gray-400 mb-6 break-keep-ko font-pretendard tracking-ko-normal">
                   Add your first subscription to start managing your services.
                 </p>
                 <Button
@@ -383,7 +383,7 @@ const Dashboard: React.FC = () => {
                           </span>
                         </div>
                         <div className="flex-1 min-w-0">
-                          <h3 className="font-semibold text-gray-900 dark:text-white text-sm truncate break-keep-ko">
+                          <h3 className="font-semibold text-gray-900 dark:text-white text-sm truncate break-keep-ko font-pretendard tracking-ko-tight">
                             {subscription.service_name}
                           </h3>
                           <div className="flex items-center gap-1 mt-1">
@@ -397,19 +397,19 @@ const Dashboard: React.FC = () => {
                       {/* Price and Details */}
                       <div className="space-y-2">
                         <div className="flex items-center justify-between">
-                          <span className="text-xs text-gray-500 dark:text-gray-400 break-keep-ko">
+                          <span className="text-xs text-gray-500 dark:text-gray-400 break-keep-ko font-pretendard tracking-ko-normal">
                             {subscription.payment_cycle}
                           </span>
-                          <span className="text-lg font-bold text-gray-900 dark:text-white">
+                          <span className="text-lg font-bold text-gray-900 dark:text-white font-pretendard tracking-ko-tight text-numeric">
                             {formatCurrency(subscription.amount, subscription.currency)}
                           </span>
                         </div>
                         
                         <div className="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
-                          <span className="break-keep-ko">
+                          <span className="break-keep-ko font-pretendard tracking-ko-normal">
                             {subscription.category || 'Uncategorized'}
                           </span>
-                          <span className="break-keep-ko">
+                          <span className="break-keep-ko font-pretendard tracking-ko-normal">
                             {subscription.payment_day ? `Day ${subscription.payment_day}` : 'No date'}
                           </span>
                         </div>
@@ -418,7 +418,7 @@ const Dashboard: React.FC = () => {
                       {/* Action Buttons */}
                       <div className="flex gap-2 mt-4 pt-3 border-t border-gray-100 dark:border-gray-700">
                         <button 
-                          className="flex-1 px-3 py-1.5 text-xs font-medium text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded-lg transition-colors"
+                          className="flex-1 px-3 py-1.5 text-xs font-medium text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded-lg transition-colors font-pretendard tracking-ko-normal"
                           onClick={(e) => {
                             e.stopPropagation();
                             window.location.href = `/subscriptions`;
@@ -427,7 +427,7 @@ const Dashboard: React.FC = () => {
                           Manage
                         </button>
                         <button 
-                          className="flex-1 px-3 py-1.5 text-xs font-medium text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg transition-colors"
+                          className="flex-1 px-3 py-1.5 text-xs font-medium text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg transition-colors font-pretendard tracking-ko-normal"
                           onClick={(e) => {
                             e.stopPropagation();
                             // TODO: Implement cancel subscription
@@ -448,7 +448,7 @@ const Dashboard: React.FC = () => {
       {/* Mini Calendar */}
       <Card className="mt-8 bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700">
         <CardHeader>
-          <CardTitle className="flex items-center gap-2 text-gray-900 dark:text-white">
+          <CardTitle className="flex items-center gap-2 text-gray-900 dark:text-white font-pretendard tracking-ko-tight">
             <Calendar className="w-5 h-5 text-purple-600" />
             Upcoming Payments
           </CardTitle>
@@ -456,7 +456,7 @@ const Dashboard: React.FC = () => {
         <CardContent>
           <div className="text-center py-8">
             <Calendar className="w-12 h-12 text-gray-400 mx-auto mb-4" />
-            <p className="text-gray-500 dark:text-gray-400 break-keep-ko">
+            <p className="text-base text-gray-500 dark:text-gray-400 break-keep-ko font-pretendard tracking-ko-normal">
               Calendar view coming soon...
             </p>
           </div>

--- a/SMS_V.2.0/src/pages/Settings.tsx
+++ b/SMS_V.2.0/src/pages/Settings.tsx
@@ -48,10 +48,10 @@ const Settings: React.FC = () => {
     <div className="container mx-auto px-4 py-8 max-w-4xl">
       {/* Header */}
       <div className="mb-8">
-        <h1 className="text-3xl font-bold text-gray-900 mb-2 break-keep-ko">
+        <h1 className="text-3xl font-bold text-gray-900 mb-2 break-keep-ko font-pretendard tracking-ko-tight">
           설정
         </h1>
-        <p className="text-gray-600 break-keep-ko">
+        <p className="text-base text-gray-600 break-keep-ko font-pretendard tracking-ko-normal">
           계정 정보와 앱 설정을 관리하세요
         </p>
       </div>

--- a/SMS_V.2.0/src/pages/Subscriptions.tsx
+++ b/SMS_V.2.0/src/pages/Subscriptions.tsx
@@ -155,10 +155,10 @@ const Subscriptions: React.FC = () => {
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-8">
         <div>
-          <h1 className="text-3xl font-bold text-gray-900 mb-2 break-keep-ko">
+          <h1 className="text-3xl font-bold text-gray-900 mb-2 break-keep-ko font-pretendard tracking-ko-tight">
             Subscriptions
           </h1>
-          <p className="text-gray-600 break-keep-ko">
+          <p className="text-base text-gray-600 break-keep-ko font-pretendard tracking-ko-normal">
             Manage your subscription services
           </p>
         </div>


### PR DESCRIPTION
Apply Moonwave design tokens to fix inconsistent typography and spacing across the UI.

This PR addresses the "Design Token Not Applied" bug, where the UI lacked consistent design rules for fonts, element spacing, and margins. By applying the defined Moonwave design tokens, including the Pretendard font, text sizing system (e.g., `text-base`, `text-lg`), and 4px-based spacing system, the changes ensure adherence to Moonwave Guide sections 3 and 4 for improved readability and visual consistency.

---

[Open in Web](https://cursor.com/agents?id=bc-7010dea4-bf19-4a3e-b1d6-c74538e9fca5) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-7010dea4-bf19-4a3e-b1d6-c74538e9fca5) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)