### PR TITLE
Run project linter

### DIFF
--- a/SMS_V.2.0/src/components/layout/MainLayout.tsx
+++ b/SMS_V.2.0/src/components/layout/MainLayout.tsx
@@ -42,6 +42,7 @@ const MainLayout: React.FC<MainLayoutProps> = ({
           <div className="frame-content">
             {/* Content Frame with improved centering */}
             <div className="frame-content-inner flex flex-col items-center justify-center min-h-full">
+              {children}
             </div>
           </div>
         </main>


### PR DESCRIPTION
Render `children` prop in `MainLayout.tsx` to fix `no-unused-vars` linting error.

---

[Open in Web](https://cursor.com/agents?id=bc-30e05443-6d87-4824-981c-2b73f19a1769) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-30e05443-6d87-4824-981c-2b73f19a1769) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)