### PR TITLE
Lint and type check for unused variables

### DIFF
--- a/SMS_V.2.0/src/components/layout/MainLayout.tsx
+++ b/SMS_V.2.0/src/components/layout/MainLayout.tsx
@@ -42,6 +42,7 @@ const MainLayout: React.FC<MainLayoutProps> = ({
           <div className="frame-content">
             {/* Content Frame with improved centering */}
             <div className="frame-content-inner flex flex-col items-center justify-center min-h-full">
+              {children}
             </div>
           </div>
         </main>


### PR DESCRIPTION
Render `children` in `MainLayout.tsx` to fix a linting error and ensure content display.

---

[Open in Web](https://cursor.com/agents?id=bc-3b8a4add-354e-4f5f-a1e9-802d4092c3c4) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-3b8a4add-354e-4f5f-a1e9-802d4092c3c4) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)