### PR TITLE
Install dependencies and build project

### DIFF
--- a/SMS_V.2.0/src/components/ui/Typography.tsx
+++ b/SMS_V.2.0/src/components/ui/Typography.tsx
@@ -4,59 +4,60 @@ import { cn } from '../../lib/utils';
 interface TypographyProps {
   children: React.ReactNode;
   className?: string;
+  id?: string;
 }
 
-const H1: React.FC<TypographyProps> = ({ children, className }) => (
+const H1: React.FC<TypographyProps> = ({ children, className, id }) => (
   <h1 className={cn(
     'text-3xl @sm:text-4xl @lg:text-5xl @xl:text-6xl',
     'font-bold tracking-ko-tight',
     'text-gray-900 break-keep-ko font-pretendard',
     className
-  )}>
+  )} id={id}>
     {children}
   </h1>
 );
 
-const H2: React.FC<TypographyProps> = ({ children, className }) => (
+const H2: React.FC<TypographyProps> = ({ children, className, id }) => (
   <h2 className={cn(
     'text-2xl @sm:text-3xl @lg:text-4xl @xl:text-5xl',
     'font-bold tracking-ko-tight',
     'text-gray-900 break-keep-ko font-pretendard',
     className
-  )}>
+  )} id={id}>
     {children}
   </h2>
 );
 
-const H3: React.FC<TypographyProps> = ({ children, className }) => (
+const H3: React.FC<TypographyProps> = ({ children, className, id }) => (
   <h3 className={cn(
     'text-xl @sm:text-2xl @lg:text-3xl @xl:text-4xl',
     'font-semibold tracking-ko-normal',
     'text-gray-900 break-keep-ko font-pretendard',
     className
-  )}>
+  )} id={id}>
     {children}
   </h3>
 );
 
-const Body: React.FC<TypographyProps> = ({ children, className }) => (
+const Body: React.FC<TypographyProps> = ({ children, className, id }) => (
   <p className={cn(
     'text-sm @sm:text-base @lg:text-lg',
     'font-normal tracking-ko-normal',
     'text-gray-700 leading-relaxed break-keep-ko font-pretendard',
     className
-  )}>
+  )} id={id}>
     {children}
   </p>
 );
 
-const Caption: React.FC<TypographyProps> = ({ children, className }) => (
+const Caption: React.FC<TypographyProps> = ({ children, className, id }) => (
   <p className={cn(
     'text-xs @sm:text-sm',
     'font-normal tracking-ko-normal',
     'text-gray-600 break-keep-ko font-pretendard',
     className
-  )}>
+  )} id={id}>
     {children}
   </p>
 );


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add `id` prop to `TypographyProps` and all Typography components to resolve TypeScript error.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The TypeScript error `TS2322` occurred because the `Typography.Caption` component was used with an `id` prop, which was not defined in its `TypographyProps` interface. This PR extends the `TypographyProps` to include an optional `id` property and ensures all Typography components correctly pass this prop to their underlying HTML elements, allowing for proper HTML attribute usage.

---

[Open in Web](https://cursor.com/agents?id=bc-4d276fcf-191f-4a29-a50b-52edc2eaf5ef) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-4d276fcf-191f-4a29-a50b-52edc2eaf5ef) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)