### PR TITLE
Fix type errors in StatisticsDashboard

### DIFF
--- a/components/StatisticsDashboard.tsx
+++ b/components/StatisticsDashboard.tsx
@@ -37,7 +37,6 @@ import {
   Train,
   Bus,
   Bike,
-  Walking,
   Home,
   Building,
   Store,
@@ -84,7 +83,24 @@ import {
   Snowflake as SnowflakeIcon,
   Cloud as CloudIcon,
   Sun as SunIcon,
-  Moon as MoonIcon
+  Moon as MoonIcon,
+  Lock,
+  AlertCircle,
+  Users,
+  Activity,
+  Clock,
+  FileText,
+  BarChart,
+  Sparkles,
+  Database,
+  TestTube,
+  Tv,
+  Code,
+  Brain,
+  Palette,
+  Dumbbell,
+  Circle,
+  Coins
 } from 'lucide-react';
 import { cn } from './ui/utils';
 import {
@@ -99,7 +115,8 @@ import {
 } from '../utils/statistics';
 import {
   loadMockDataFromLocalStorage,
-  initializeMockData
+  initializeMockData,
+  generateAllMockData
 } from '../utils/mockData';
 
 interface StatisticsData {
@@ -248,7 +265,7 @@ export function StatisticsDashboard() {
           setError('실제 데이터를 불러올 수 없어 가상 데이터를 사용합니다.');
           
           // 가상 데이터로 즉시 전환
-          const mockData = initializeMockData();
+          const mockData = generateAllMockData();
           
           dashboardData = {
             total_spend_krw: mockData.monthlySpendingTrends[11]?.total_spend_krw || 150000,
@@ -303,7 +320,7 @@ export function StatisticsDashboard() {
 
       if (!dashboardData) {
         // 가상 데이터 사용
-        const mockData = initializeMockData();
+        const mockData = generateAllMockData();
         
         dashboardData = {
           total_spend_krw: mockData.monthlySpendingTrends[11]?.total_spend_krw || 150000,
@@ -414,7 +431,7 @@ export function StatisticsDashboard() {
       case 'decreasing':
         return <TrendingDown className="text-red-500 drop-shadow-lg" size={20} />;
       case 'stable':
-        return <Equal className="text-blue-500 drop-shadow-lg" size={20} />;
+        return <Minus className="text-blue-500 drop-shadow-lg" size={20} />;
     }
   };
 


### PR DESCRIPTION
## 📋 변경 사항 설명
`components/StatisticsDashboard.tsx` 파일 내 TypeScript 오류를 수정했습니다.

주요 변경 사항은 다음과 같습니다:
- `initializeMockData()`가 `void`를 반환하여 발생하던 타입 오류를 `generateAllMockData()`를 사용하여 실제 데이터를 반환하도록 수정했습니다.
- 존재하지 않는 `lucide-react` 아이콘(`Walking`, `Equal`)을 제거하거나 대체하고, 누락된 `Lock` 아이콘을 추가했습니다.

## 🔧 변경 타입
- [x] 🐛 버그 수정

## 🧪 테스트
- [x] 로컬에서 테스트 완료
- [x] 모든 CI 테스트 통과 (타입 체크 및 린트)
- [ ] 새로운 테스트 케이스 추가됨

## 📸 스크린샷 (해당하는 경우)
<!-- UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
N/A

## 🔗 관련 이슈
<!-- 관련 이슈가 있다면 링크를 추가해주세요 -->
Closes #

## ✅ 체크리스트
- [x] 코드가 ESLint 규칙을 준수합니다
- [x] TypeScript 타입 체크를 통과합니다
- [x] 빌드가 성공적으로 완료됩니다
- [x] 변경사항에 대한 테스트를 작성했습니다 (기존 테스트 통과 확인)
- [ ] 문서가 업데이트되었습니다 (필요한 경우)

## 🚀 배포 참고사항
<!-- 배포 시 주의할 점이나 추가 설정이 필요한 경우 -->
없음

---
<a href="https://cursor.com/background-agent?bcId=bc-b451a3e9-01fd-40c7-8306-7a3d17a52318">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b451a3e9-01fd-40c7-8306-7a3d17a52318">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>